### PR TITLE
Fix array indexing when no record is selected

### DIFF
--- a/Timeless Recordplayer/Timeless Recordplayer/Game.cpp
+++ b/Timeless Recordplayer/Timeless Recordplayer/Game.cpp
@@ -138,17 +138,19 @@ void Game::update(sf::Time t_deltaTime)
 	checkVinylPlayerCollision(); // checks if vinyl is on record player - plays music if true
 	checkVinylAlbumCollision();
 
-	if (albums[m_albumRevealed].m_revealAlbum &&
-		albums[m_albumRevealed].m_revealedBy < albums[m_albumRevealed].MAX_REVEAL_BY) // moves up record until revealed or switched
-	{
-		albums[m_albumRevealed].moveUp();
-		albums[m_albumRevealed].m_revealedBy++;
-	}
-	else if (albums[m_albumRevealed].m_revealedBy == albums[m_albumRevealed].MAX_REVEAL_BY)
-	{
-		if (!m_holdingVinyl)
+	if (m_albumRevealed != NO_ALBUM_REVEALED) {
+		if (albums[m_albumRevealed].m_revealAlbum &&
+			albums[m_albumRevealed].m_revealedBy < albums[m_albumRevealed].MAX_REVEAL_BY) // moves up record until revealed or switched
 		{
-			m_instructions.setString("CLICK  THE  CHOSEN  COVER  TO  TAKE  THE  VINYL  OUT");
+			albums[m_albumRevealed].moveUp();
+			albums[m_albumRevealed].m_revealedBy++;
+		}
+		else if (albums[m_albumRevealed].m_revealedBy == albums[m_albumRevealed].MAX_REVEAL_BY)
+		{
+			if (!m_holdingVinyl)
+			{
+				m_instructions.setString("CLICK  THE  CHOSEN  COVER  TO  TAKE  THE  VINYL  OUT");
+			}
 		}
 	}
 

--- a/Timeless Recordplayer/Timeless Recordplayer/Game.h
+++ b/Timeless Recordplayer/Timeless Recordplayer/Game.h
@@ -67,8 +67,8 @@ private:
 	sf::Vector2f m_mouseEndVector; // converts to vector
 	sf::CircleShape m_mouseDot{1.0f}; // used to check collisions
 
-
-	int m_albumRevealed = -1; // tracking the album currently revealed
+	static constexpr int NO_ALBUM_REVEALED = -1; // magical constant for no album revealed
+	int m_albumRevealed = NO_ALBUM_REVEALED; // tracking the album currently revealed
 	bool m_holdingVinyl = false; // if the vinyl is held
 
 	bool m_mouseReleased = true; // if mouse is released or not


### PR DESCRIPTION
When the game was started with `m_albumRevealed = -1`, the code soon used this negative value to index the albums array, causing out of bounds access. This PR creates a constant for the _no album selected_ state, and checks that this is not the value of the `m_albumRevealed` variable before indexing into the array.

This was also the reason why the message about scrolling wasn't being displayed (at least on my machine), now it also works.

---

I'm a big fan of games by Amanita Design, and this small piece really reminded them of their game style. Love it!